### PR TITLE
Create env target in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ halt: .mac_address
 	'
 	@echo "Shutting down..."
 
+env:
+	@echo export DOCKER_HOST=tcp://`make ip`:2375
+
 uuid2ip: uuid2ip/build/uuid2mac
 
 uuid2ip/build/uuid2mac:


### PR DESCRIPTION
It is useful to configure environment:

``` bash
$(make env)
```
